### PR TITLE
feat: Adding support for customized drain conditions

### DIFF
--- a/cmd/mechanic/main.go
+++ b/cmd/mechanic/main.go
@@ -120,7 +120,7 @@ func main() {
 			node := new.(*v1.Node)
 			log.Infow("Node updated, checking for updated conditions", "node", node.Name)
 
-			state.HasEventScheduled = n.CheckNodeConditions(ctx, node)
+			state.HasEventScheduled = n.CheckNodeConditions(ctx, node, cfg.DrainConditions)
 
 			log.Infow("Finished checking node conditions and current state.", "node", node.Name, "state", &state)
 
@@ -132,7 +132,7 @@ func main() {
 				}
 
 				// query IMDS for more information on the scheduled event
-				b, err := imds.CheckIfDrainRequired(ctx, ic, node)
+				b, err := imds.CheckIfDrainRequired(ctx, ic, node, &cfg.DrainConditions)
 				if err != nil {
 					log.Errorw("Failed to query IMDS for scheduled event information. Unable to determine if drain is required.", "error", err, "state", &state)
 					return

--- a/deploy/base/mechanic.ds.yaml
+++ b/deploy/base/mechanic.ds.yaml
@@ -89,6 +89,19 @@ subjects:
     name: mechanic
     namespace: mechanic
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mechanic
+  namespace: mechanic
+data:
+  mechanic.yaml: |
+    DRAIN_ON_FREEZE: true
+    DRAIN_ON_REBOOT: true
+    DRAIN_ON_REDEPLOY: false
+    DRAIN_ON_PREEMPT: true
+    DRAIN_ON_TERMINATE: true
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,3 +88,29 @@ func buildDrainConditions(config *viper.Viper) DrainConditions {
 		DrainOnTerminate: config.GetBool("DRAIN_ON_TERMINATE"),
 	}
 }
+
+func (dc *DrainConditions) DrainableConditions() []string {
+	drainableConditions := []string{}
+
+	if dc.DrainOnFreeze {
+		drainableConditions = append(drainableConditions, "Freeze")
+	}
+
+	if dc.DrainOnReboot {
+		drainableConditions = append(drainableConditions, "Reboot")
+	}
+
+	if dc.DrainOnRedeploy {
+		drainableConditions = append(drainableConditions, "Redeploy")
+	}
+
+	if dc.DrainOnPreempt {
+		drainableConditions = append(drainableConditions, "Preempt")
+	}
+
+	if dc.DrainOnTerminate {
+		drainableConditions = append(drainableConditions, "Terminate")
+	}
+
+	return drainableConditions
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-
 	"github.com/amargherio/mechanic/internal/appstate"
 	"github.com/spf13/viper"
 
@@ -12,6 +11,11 @@ import (
 
 // DrainConditions is a struct that holds the VM scheduled event types that would trigger a drain
 type DrainConditions struct {
+	DrainOnFreeze    bool
+	DrainOnReboot    bool
+	DrainOnRedeploy  bool
+	DrainOnPreempt   bool
+	DrainOnTerminate bool
 }
 
 // ContextValues is a struct that holds the logger and state of the application for use in the shared application context
@@ -35,6 +39,22 @@ func ReadConfiguration(ctx context.Context) (Config, error) {
 	log.Debugw("Generating app config")
 
 	config := viper.New()
+
+	// set defaults for the config
+	config.SetDefault("DRAIN_ON_FREEZE", false)
+	config.SetDefault("DRAIN_ON_REBOOT", false)
+	config.SetDefault("DRAIN_ON_REDEPLOY", true)
+	config.SetDefault("DRAIN_ON_PREEMPT", true)
+	config.SetDefault("DRAIN_ON_TERMINATE", true)
+
+	// set viper to watch for a mounted config file and read it in, handling the error gracefully if it's missing
+	config.SetConfigName("mechanic")
+	config.AddConfigPath("/etc/mechanic")
+	config.SetConfigType("yaml")
+	if err := config.ReadInConfig(); err != nil {
+		log.Warnw("Failed to read in config file, proceeding with default values and environment variables", "error", err)
+	}
+
 	config.SetEnvPrefix("MECHANIC")
 	config.BindEnv("NODE_NAME")
 
@@ -44,11 +64,27 @@ func ReadConfiguration(ctx context.Context) (Config, error) {
 		return Config{}, err
 	}
 
+	// build our config for handling different drain conditions
+	drainConfig := buildDrainConditions(config)
+
 	log.Debugw("Successfully read configuration", "config", config.AllSettings())
 
 	return Config{
-		DrainConditions: DrainConditions{},
+		DrainConditions: drainConfig,
 		KubeConfig:      kc,
 		NodeName:        config.Get("NODE_NAME").(string),
 	}, nil
+}
+
+// buildDrainConditions is a helper function that builds the DrainConditions struct from the mechanic config map in the cluster.
+// if no config is found, it will return a struct with default values that match the behavior indicated at
+// https://learn.microsoft.com/en-us/azure/aks/node-auto-repair#node-auto-drain
+func buildDrainConditions(config *viper.Viper) DrainConditions {
+	return DrainConditions{
+		DrainOnFreeze:    config.GetBool("DRAIN_ON_FREEZE"),
+		DrainOnReboot:    config.GetBool("DRAIN_ON_REBOOT"),
+		DrainOnRedeploy:  config.GetBool("DRAIN_ON_REDEPLOY"),
+		DrainOnPreempt:   config.GetBool("DRAIN_ON_PREEMPT"),
+		DrainOnTerminate: config.GetBool("DRAIN_ON_TERMINATE"),
+	}
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,3 +1,14 @@
 package consts
 
 const IMDS_SCHEDULED_EVENTS_API_ENDPOINT = "http://169.254.169.254/metadata/scheduledevents"
+
+type NodeCondition string
+
+const (
+	Freeze    NodeCondition = "FreezeScheduled"
+	Reboot    NodeCondition = "RebootScheduled"
+	Redeploy  NodeCondition = "RedeployScheduled"
+	Preempt   NodeCondition = "PreemptScheduled"
+	Terminate NodeCondition = "TerminateScheduled"
+	VMEvent   NodeCondition = "VMEventScheduled"
+)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -405,7 +405,57 @@ func TestCheckNodeConditions(t *testing.T) {
 			expectedResponse: true,
 		},
 		{
-			name: "node has no VMScheduledEvent",
+			name: "node has FreezeScheduled",
+			prepNodeFunc: func(n *v1.Node) {
+				n.Status.Conditions = append(n.Status.Conditions, v1.NodeCondition{
+					Type:   v1.NodeConditionType("FreezeScheduled"),
+					Status: v1.ConditionTrue,
+				})
+			},
+			expectedResponse: true,
+		},
+		{
+			name: "node has RebootScheduled",
+			prepNodeFunc: func(n *v1.Node) {
+				n.Status.Conditions = append(n.Status.Conditions, v1.NodeCondition{
+					Type:   v1.NodeConditionType("RebootScheduled"),
+					Status: v1.ConditionTrue,
+				})
+			},
+			expectedResponse: true,
+		},
+		{
+			name: "node has RedeployScheduled",
+			prepNodeFunc: func(n *v1.Node) {
+				n.Status.Conditions = append(n.Status.Conditions, v1.NodeCondition{
+					Type:   v1.NodeConditionType("RedeployScheduled"),
+					Status: v1.ConditionTrue,
+				})
+			},
+			expectedResponse: true,
+		},
+		{
+			name: "node has PreemptScheduled",
+			prepNodeFunc: func(n *v1.Node) {
+				n.Status.Conditions = append(n.Status.Conditions, v1.NodeCondition{
+					Type:   v1.NodeConditionType("PreemptScheduled"),
+					Status: v1.ConditionTrue,
+				})
+			},
+			expectedResponse: true,
+		},
+		{
+			name: "node has TerminateScheduled",
+			prepNodeFunc: func(n *v1.Node) {
+				n.Status.Conditions = append(n.Status.Conditions, v1.NodeCondition{
+					Type:   v1.NodeConditionType("TerminateScheduled"),
+					Status: v1.ConditionTrue,
+				})
+			},
+			expectedResponse: true,
+		},
+		{
+			name: "node has no scheduled events",
 			prepNodeFunc: func(n *v1.Node) {
 			},
 			expectedResponse: false,
@@ -428,7 +478,13 @@ func TestCheckNodeConditions(t *testing.T) {
 			ctx := context.WithValue(context.Background(), "values", vals)
 
 			tc.prepNodeFunc(node)
-			response := CheckNodeConditions(ctx, node)
+			response := CheckNodeConditions(ctx, node, config.DrainConditions{
+				DrainOnFreeze:    true,
+				DrainOnReboot:    true,
+				DrainOnRedeploy:  true,
+				DrainOnPreempt:   true,
+				DrainOnTerminate: true,
+			})
 			assert.Equal(t, tc.expectedResponse, response, "Expected response to be %v, got %v", tc.expectedResponse, response)
 		})
 	}


### PR DESCRIPTION
Baseline functionality in mechanic covers freeze events specific to live migrations and indicates that a drain is required for scheduled events of any other type. This PR should bring parity to the drain behavior and align it with what's defined at https://learn.microsoft.com/en-us/azure/aks/node-auto-repair#node-auto-drain.

This also allows a user to disable drain for event types they don't care for. The new logic is completely covered in updated IMDS and node condition tests. There's room to optimize how we're doing event checks to determine if a drain is required (i.e., should we check for a `FreezeScheduled` event or would an event of `FreezeScheduled` also flip the node condition for `VMEventScheduled` to true?) but it's functional as of this PR.

This closes #1 when it's merged.