### PR TITLE
chore(release): Windows image builds

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -150,12 +150,12 @@ jobs:
             --platform windows/amd64 `
             --build-arg BIN_PATH=dist/mechanic_windows_amd64*/mechanic.exe `
             --build-arg RUNTIME_IMAGE=${{ env.windows_runtime_image }} `
-            --tag ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022-amd64 `
+            --tag ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022 `
             -f build/windows.Dockerfile .
 
       - name: Push images to registry
         run: |
-          docker push ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022-amd64
+          docker push ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022
 
   build-windows-2019-containers:
     permissions:
@@ -195,9 +195,9 @@ jobs:
             --platform windows/amd64 `
             --build-arg BIN_PATH=dist/mechanic_windows_amd64*/mechanic.exe `
             --build-arg RUNTIME_IMAGE=${{ env.windows_runtime_image }} `
-            --tag ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2019-amd64 `
+            --tag ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2019 `
             -f build/windows.Dockerfile .
 
       - name: Push images to registry
         run: |
-          docker push ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022-amd64
+          docker push ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2019

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -156,3 +156,48 @@ jobs:
       - name: Push images to registry
         run: |
           docker push ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022-amd64
+
+  build-windows-2019-containers:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    runs-on: windows-2019
+    needs: build-go-binaries
+
+    env:
+      target_container_registry: ghcr.io/amargherio
+      target_container_tag: $(echo ${{ github.ref }} | sed 's/refs\/tags\///')
+      windows_runtime_image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: go-binaries
+          path: dist
+
+      - name: Fix file permissions for executables
+        run: |
+          chmod +x dist/mechanic_windows_*/mechanic
+                
+      - name: Log in to container registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login --username ${{ secrets.CONTAINER_REGISTRY_USERNAME }} --password-stdin ${{ env.target_container_registry}}
+
+      - name: Build Windows 2019 images
+        run: |
+          docker build `
+            --platform windows/amd64 `
+            --build-arg BIN_PATH=dist/mechanic_windows_amd64*/mechanic.exe `
+            --build-arg RUNTIME_IMAGE=${{ env.windows_runtime_image }} `
+            --tag ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2019-amd64 `
+            -f build/windows.Dockerfile .
+
+      - name: Push images to registry
+        run: |
+          docker push ${{ env.target_container_registry}}/mechanic:${{ env.target_container_tag }}-windows2022-amd64

--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ There are some caveats and items worth noting:
 
 - The DaemonSet is deployed in a custom `mechanic` namespace. This is to ensure that the DaemonSet can be managed independently
   of other resources in the cluster.
-- The Kustomize base doesn't have a valid image URL. It's required that you build the image and push it to a registry that
-  your cluster can pull from. Once the iamge is in a registry, you can create a patch to have Kustomize update the image URL.
+- The Kustomize base offers a prebuilt image hosted in the GitHub Container Registry packages of this repository. If you choose,
+  you can build your own image or pull the image from the GitHub Container Registry for this project and push it into
+  your own registry. Once the image is in a registry, you can create a patch to have Kustomize update the image URL.
 - All images use a base container image of Azure Linux.
 
 ## How does it work?
 
-**mechanic** runs as a DaemonSet in your cluster. Each daemon pod monitors node updates and, for each update, checks the 
+**mechanic** runs as a DaemonSet in your cluster. Each daemon pod monitors node updates and, for each update, checks the
 node conditions. If a `VMEventScheduled` condition is present, it queries the [Instance Metadata Service](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux) for maintenance
 information.
 

--- a/deploy/base/mechanic.ds.yaml
+++ b/deploy/base/mechanic.ds.yaml
@@ -125,7 +125,7 @@ spec:
       hostPID: true # Facilitates entering the host mount namespace via init
       containers:
       - name: mechanic
-        image: image:tag
+        image: ghcr.io/amargherio/mechanic:v0.2.0-distroless-nonroot
         imagePullPolicy: Always
         securityContext:
           privileged: true # Gives permission to nsenter /proc/1/ns/mnt


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adding Windows 2019 and Windows 2022 image builds
- Enabling the last bits of repo-provided images

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
