### PR TITLE
feat: Updated observability and improved logging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,7 @@ builds:
       - s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
     gcflags:
       - all=-l -B
+      #- all=-N -l # useful for remote execution of commands during debugging
     goos:
       - linux
       - windows

--- a/build/debug.Dockerfile
+++ b/build/debug.Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y curl \
+    && curl -kLO https://go.dev/dl/go1.23.2.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.23.2.linux-amd64.tar.gz \
+    && rm go1.23.2.linux-amd64.tar.gz \
+    && export PATH=$PATH:/usr/local/go/bin \
+    && go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Copy the build artifacts from the previous stage
+ARG BIN_PATH=./mechanic
+
+COPY $BIN_PATH /usr/local/bin/mechanic
+
+CMD ["/root/go/bin/dlv", "exec", "/usr/local/bin/mechanic", "--headless", "--listen=:2345", "--api-version=2", "--accept-multiclient", "--log"]

--- a/cmd/mechanic/main.go
+++ b/cmd/mechanic/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 
 	// tracing bootstrapping
-	tp, err := tracing.InitTracer()
+	tp, _ := tracing.InitTracer()
 	// todo: should we defer TracerProvider shutdown here?
 	tracer := otel.Tracer("github.com/amargherio/mechanic")
 

--- a/internal/logging/trace_logger.go
+++ b/internal/logging/trace_logger.go
@@ -1,0 +1,60 @@
+package logging
+
+import (
+	"context"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type TraceCore struct {
+	zapcore.Core
+	Ctx *context.Context
+	tp  trace.TracerProvider
+}
+
+// NewTraceCore Returns a new Core that adds tracing information to the log entry
+func NewTraceCore(c zapcore.Core, ctx *context.Context, tp trace.TracerProvider) *TraceCore {
+	return &TraceCore{c, ctx, tp}
+}
+
+// With adds structured context to the Core
+func (c *TraceCore) With(fields []zapcore.Field) zapcore.Core {
+	return &TraceCore{
+		Core: c.Core.With(fields),
+		Ctx:  c.Ctx,
+		tp:   c.tp,
+	}
+}
+
+func (c *TraceCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if ce := c.Core.Check(e, ce); ce != nil {
+
+		return ce.AddCore(e, c)
+	}
+	return ce
+}
+
+// Write serializes the Entry and any Fields, along with the trace information, to the Core
+func (c *TraceCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	// Get the current span from the context, if there is one
+	if span := trace.SpanFromContext(*c.Ctx); span != nil {
+		spanContext := span.SpanContext()
+		if spanContext.IsValid() {
+			fields = append(
+				fields,
+				zap.String("traceID", spanContext.TraceID().String()),
+				zap.String("spanID", spanContext.SpanID().String()),
+			)
+
+			if entry.Level == zapcore.DebugLevel {
+				fields = append(fields, zap.Any("spanContext", spanContext))
+			}
+		}
+	}
+	return c.Core.Write(entry, fields)
+}
+
+func (c *TraceCore) Sync() error {
+	return c.Core.Sync()
+}

--- a/internal/logging/trace_logger.go
+++ b/internal/logging/trace_logger.go
@@ -2,15 +2,16 @@ package logging
 
 import (
 	"context"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type TraceCore struct {
-	zapcore.Core
-	Ctx *context.Context
-	tp  trace.TracerProvider
+	ioCore zapcore.Core
+	Ctx    *context.Context
+	tp     trace.TracerProvider
 }
 
 // NewTraceCore Returns a new Core that adds tracing information to the log entry
@@ -18,18 +19,17 @@ func NewTraceCore(c zapcore.Core, ctx *context.Context, tp trace.TracerProvider)
 	return &TraceCore{c, ctx, tp}
 }
 
+func (c *TraceCore) Enabled(lvl zapcore.Level) bool {
+	return c.ioCore.Enabled(lvl)
+}
+
 // With adds structured context to the Core
 func (c *TraceCore) With(fields []zapcore.Field) zapcore.Core {
-	return &TraceCore{
-		Core: c.Core.With(fields),
-		Ctx:  c.Ctx,
-		tp:   c.tp,
-	}
+	return c.ioCore.With(fields)
 }
 
 func (c *TraceCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if ce := c.Core.Check(e, ce); ce != nil {
-
+	if c.Enabled(e.Level) {
 		return ce.AddCore(e, c)
 	}
 	return ce
@@ -37,24 +37,47 @@ func (c *TraceCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.Ch
 
 // Write serializes the Entry and any Fields, along with the trace information, to the Core
 func (c *TraceCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
-	// Get the current span from the context, if there is one
-	if span := trace.SpanFromContext(*c.Ctx); span != nil {
-		spanContext := span.SpanContext()
-		if spanContext.IsValid() {
-			fields = append(
-				fields,
-				zap.String("traceID", spanContext.TraceID().String()),
-				zap.String("spanID", spanContext.SpanID().String()),
-			)
+	// 1. get the supplied context from the fields (or the span if the context doesn't cut it).
+	// 2. if context, get the span from the context
+	// 3. using the span, add the trace ID, span ID, and name to the logged fields
+	// 4. write the entry to the core
 
-			if entry.Level == zapcore.DebugLevel {
-				fields = append(fields, zap.Any("spanContext", spanContext))
-			}
+	// Get the current span from the context, if there is one
+	var sc context.Context
+	var activeSpan trace.Span
+	for _, field := range fields {
+		if field.Key == "traceCtx" {
+			sc = field.Interface.(context.Context)
+			break
 		}
 	}
-	return c.Core.Write(entry, fields)
+	if sc == nil {
+		return c.ioCore.Write(entry, fields)
+	}
+	activeSpan = trace.SpanFromContext(sc)
+
+	// if we still didn't get an active span, skip those extra fields and write the entry
+	// todo: should we also check if the active span is recording here?
+	if activeSpan != nil && activeSpan.SpanContext().IsValid() {
+		ros := activeSpan.(sdktrace.ReadOnlySpan)
+		fields = append(
+			fields,
+			zap.String("traceID", ros.SpanContext().TraceID().String()),
+			zap.String("spanID", ros.SpanContext().SpanID().String()),
+			zap.String("spanName", ros.Name()),
+		)
+
+		if entry.Level == zapcore.DebugLevel {
+			fields = append(fields,
+				zap.Any("spanContext", ros.SpanContext()),
+				zap.Any("spanAttributes", ros.Attributes()),
+				zap.Any("rawSpan", ros),
+			)
+		}
+	}
+	return c.ioCore.Write(entry, fields)
 }
 
 func (c *TraceCore) Sync() error {
-	return c.Core.Sync()
+	return c.ioCore.Sync()
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -6,20 +6,15 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/noop"
+	"io"
 )
 
-func InitTracer(shouldTrace bool) (trace.TracerProvider, error) {
-	// exit early with no-op if tracing isn't enabled
-	if !shouldTrace {
-		tp := noop.NewTracerProvider()
-		otel.SetTracerProvider(tp)
-		return tp, nil
-	}
-
+func InitTracer() (trace.TracerProvider, error) {
 	// configure the stdout exporter
 	// todo: add support for additional exporters
-	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	options := stdouttrace.WithWriter(io.Discard)
+	exporter, err := stdouttrace.New(options)
+	//exporter, err := stdouttrace.New()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imds/imds_test.go
+++ b/pkg/imds/imds_test.go
@@ -223,7 +223,7 @@ func TestCheckIfDrainRequired(t *testing.T) {
 				State:  &state,
 			}
 
-			ctx := context.WithValue(context.Background(), "values", vals)
+			ctx := context.WithValue(context.Background(), "values", &vals)
 
 			mockIMDS := configureMocks(tc, ctrl)
 

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -95,7 +95,7 @@ func TestCordonNode(t *testing.T) {
 				State:  &state,
 			}
 
-			ctx := context.WithValue(context.Background(), "values", vals)
+			ctx := context.WithValue(context.Background(), "values", &vals)
 
 			cordoned, err := CordonNode(ctx, clientset, node)
 			if (err != nil) != tc.expectError {
@@ -160,7 +160,7 @@ func TestDrainNode(t *testing.T) {
 				State:  &state,
 			}
 
-			ctx := context.WithValue(context.Background(), "values", vals)
+			ctx := context.WithValue(context.Background(), "values", &vals)
 
 			drained, err := DrainNode(ctx, clientset, node)
 			if (err != nil) != tc.expectError {
@@ -354,7 +354,7 @@ func TestValidateCordon(t *testing.T) {
 				State:  tc.inputState,
 			}
 
-			ctx := context.WithValue(context.Background(), "values", vals)
+			ctx := context.WithValue(context.Background(), "values", &vals)
 
 			nodeName := "test-node"
 			node := &v1.Node{
@@ -475,7 +475,7 @@ func TestCheckNodeConditions(t *testing.T) {
 				State: &appstate.State{
 					HasEventScheduled: false, IsCordoned: false, ShouldDrain: false, IsDrained: false},
 			}
-			ctx := context.WithValue(context.Background(), "values", vals)
+			ctx := context.WithValue(context.Background(), "values", &vals)
 
 			tc.prepNodeFunc(node)
 			response := CheckNodeConditions(ctx, node, config.DrainConditions{


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #16 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Simplified the tracing components in mechanic today. It'll always use a stdouttrace exporter.
- Implemented a custom zapcore logger for injecting trace ID and span details into log messages.
- Changed the steps at startup to initialize the logger and tracer and load in the correct config values.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
This PR establishes a baseline for distributed tracing and implements a default OpenTelemetry setup. It's not going to be terribly advanced or extensible at this time and doesn't support custom exporters.

The big driver behind this effort is being able to associate logs back to a given operation by using the trace ID generated by the otel traces and spans created and managed as part of the regular app logic.