### PR TITLE
chore: Windows 2019 and 2022 YAML updates

### DIFF
--- a/deploy/base/mechanic-win2019.ds.yaml
+++ b/deploy/base/mechanic-win2019.ds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: mechanic-win19
+  name: mechanic-win2019
   namespace: mechanic
 spec:
   selector:

--- a/deploy/base/mechanic-win2019.ds.yaml
+++ b/deploy/base/mechanic-win2019.ds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: mechanic
+  name: mechanic-win19
   namespace: mechanic
 spec:
   selector:
@@ -16,13 +16,14 @@ spec:
         app: mechanic
     spec:
       nodeSelector:
-        kubernetes.io/os: linux
+        kubernetes.io/os: windows
         kubernetes.io/arch: amd64
+        kubernetes.io/os-sku: Windows2019
       serviceAccountName: mechanic
       hostPID: true # Facilitates entering the host mount namespace via init
       containers:
       - name: mechanic
-        image: ghcr.io/amargherio/mechanic:v0.2.0-distroless-nonroot
+        image: ghcr.io/amargherio/mechanic:v0.2.0-windows2019
         imagePullPolicy: Always
         securityContext:
           privileged: true # Gives permission to nsenter /proc/1/ns/mnt

--- a/deploy/base/mechanic-win2022.ds.yaml
+++ b/deploy/base/mechanic-win2022.ds.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: mechanic
+  name: mechanic-win2022
   namespace: mechanic
 spec:
   selector:

--- a/deploy/base/mechanic-win2022.ds.yaml
+++ b/deploy/base/mechanic-win2022.ds.yaml
@@ -18,6 +18,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: windows
         kubernetes.io/arch: amd64
+        kubernetes.io/os-sku: Windows2022
       serviceAccountName: mechanic
       hostPID: true # Facilitates entering the host mount namespace via init
       containers:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): Release YAML updates for Kustomize base

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The YAML used in the Kustomize base for the Windows 2019 and 2022 daemonsets had invalid image tags and node selectors.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
The daemonsets now have appropriate selectors to put 2019 and 2022 Windows containers on the correct nodes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
