### PR TITLE
feat: bypassing node problem detector and manually querying IMDS

### DIFF
--- a/cmd/mechanic/main.go
+++ b/cmd/mechanic/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/amargherio/mechanic/internal/appstate"
 	"github.com/amargherio/mechanic/internal/config"
@@ -12,6 +14,7 @@ import (
 	"github.com/amargherio/mechanic/pkg/imds"
 	n "github.com/amargherio/mechanic/pkg/node"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/api/core/v1"
@@ -102,142 +105,271 @@ func main() {
 
 	state.IsCordoned = node.Spec.Unschedulable
 
-	log.Info("Building the informer factory for our node informer client.")
-	factory := informers.NewSharedInformerFactoryWithOptions(
-		clientset,
-		0,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = fmt.Sprintf("metadata.name=%s", cfg.NodeName)
-		}),
-	)
+	// if BypassNodeProblemDetector is true, we don't set up the informer for node updates
+	if cfg.BypassNodeProblemDetector {
+		log.Infow("Bypassing Node Problem Detector, not setting up informer and querying IMDS directly", "node", cfg.NodeName)
 
-	ni := factory.Core().V1().Nodes().Informer()
-	ni.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
-		UpdateFunc: func(old, new interface{}) {
-			ctx, span := tracer.Start(ctx, "nodeUpdateHandler")
-			defer span.End()
-			// lock the state object so we know we have it exclusively for this function
-			// if we can't get the lock, then we skip processing this node update because we're already processing another one
-			//
-			// todo: this may need cleanup - there's no reads to state outside of processing an node update but it would be good to
-			// 	 ensure that we don't end up needing a RWMutex instead.
-			didLock := state.Lock.TryLock()
-			if !didLock {
-				log.Warnw("Failed to lock state object, skipping update",
-					"node", cfg.NodeName,
-					"traceCtx", ctx)
+		// Create a cancellable context for graceful shutdown
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// Start periodic IMDS querying with 10s interval and jitter
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				// Add jitter of ±0.5 seconds
+				jitter := time.Duration((rand.Float64() - 0.5) * float64(time.Second))
+				time.Sleep(jitter)
+
+				handleIMDSCheck(ctx, clientset, &cfg, &state, &ic, recorder, tracer, log)
+			case <-ctx.Done():
+				log.Infow("Context cancelled, shutting down IMDS monitoring", "node", cfg.NodeName)
 				return
 			}
-			log.Debugw("Locked state object", "node", cfg.NodeName,
-				"state", &state,
-				"traceCtx", ctx)
-			defer func() {
-				state.Lock.Unlock()
-				log.Debugw("Unlocked state object",
-					"node", cfg.NodeName,
-					"state", &state,
-					"traceCtx", ctx)
-			}()
+		}
+	} else {
 
-			node := new.(*v1.Node)
-			log.Infow("Node updated, checking for updated conditions",
-				"node", node.Name,
-				"traceCtx", ctx)
+		log.Info("Building the informer factory for our node informer client.")
+		factory := informers.NewSharedInformerFactoryWithOptions(
+			clientset,
+			0,
+			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+				options.FieldSelector = fmt.Sprintf("metadata.name=%s", cfg.NodeName)
+			}),
+		)
 
-			state.HasDrainableCondition, state.ConditionIsScheduledEvent = n.CheckNodeConditions(ctx, node, &cfg.ScheduledEventDrainConditions, &cfg.OptionalDrainConditions)
-
-			log.Infow("Finished checking node conditions and current state.", "node", node.Name, "state", &state, "traceCtx", ctx)
-
-			if state.HasDrainableCondition {
-				// early return if the node is already cordoned and drained
-				if state.IsCordoned && state.IsDrained {
-					log.Infow("Node is already cordoned and drained, no action required", "node", node.Name, "state", &state, "traceCtx", ctx)
+		ni := factory.Core().V1().Nodes().Informer()
+		ni.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
+			UpdateFunc: func(old, new interface{}) {
+				ctx, span := tracer.Start(ctx, "nodeUpdateHandler")
+				defer span.End()
+				// lock the state object so we know we have it exclusively for this function
+				// if we can't get the lock, then we skip processing this node update because we're already processing another one
+				//
+				// todo: this may need cleanup - there's no reads to state outside of processing an node update but it would be good to
+				// 	 ensure that we don't end up needing a RWMutex instead.
+				didLock := state.Lock.TryLock()
+				if !didLock {
+					log.Warnw("Failed to lock state object, skipping update",
+						"node", cfg.NodeName,
+						"traceCtx", ctx)
 					return
 				}
+				log.Debugw("Locked state object", "node", cfg.NodeName,
+					"state", &state,
+					"traceCtx", ctx)
+				defer func() {
+					state.Lock.Unlock()
+					log.Debugw("Unlocked state object",
+						"node", cfg.NodeName,
+						"state", &state,
+						"traceCtx", ctx)
+				}()
 
-				state.ShouldDrain = true // setting the drain decision to true unless we can overturn it
+				node := new.(*v1.Node)
+				log.Infow("Node updated, checking for updated conditions",
+					"node", node.Name,
+					"traceCtx", ctx)
 
-				// if the condition is a scheduled event, we need to check and differentiate between a freeze event and a live migration
-				if state.ConditionIsScheduledEvent {
-					log.Infow("Node has a scheduled event condition, checking for freeze or live migration", "node", node.Name, "state", &state, "traceCtx", ctx)
-					isLM, err := imds.CheckIfFreezeOrLiveMigration(ctx, ic, node, &cfg.ScheduledEventDrainConditions)
-					if err != nil {
-						log.Errorw("Failed to query IMDS for scheduled event information. Unable to determine if drain is required.", "error", err, "state", &state, "traceCtx", ctx)
+				state.HasDrainableCondition, state.ConditionIsScheduledEvent = n.CheckNodeConditions(ctx, node, &cfg.ScheduledEventDrainConditions, &cfg.OptionalDrainConditions)
+
+				log.Infow("Finished checking node conditions and current state.", "node", node.Name, "state", &state, "traceCtx", ctx)
+
+				if state.HasDrainableCondition {
+					// early return if the node is already cordoned and drained
+					if state.IsCordoned && state.IsDrained {
+						log.Infow("Node is already cordoned and drained, no action required", "node", node.Name, "state", &state, "traceCtx", ctx)
 						return
 					}
 
-					if !isLM && !cfg.ScheduledEventDrainConditions.Freeze {
-						log.Infow("Node has a freeze event that is not a live migration. We don't currently drain for freeze events, so setting our drain decision to false.", "node", node.Name, "state", &state, "traceCtx", ctx)
-						state.ShouldDrain = false
-					} else if isLM && !cfg.ScheduledEventDrainConditions.LiveMigration {
-						log.Infow("Node has a live migration event but draining for live migration is disabled. Setting our drain decision to false.", "node", node.Name, "state", &state, "traceCtx", ctx)
-						state.ShouldDrain = false
-					} else {
-						log.Infow("Node has a scheduled event condition that is a live migration. We will drain for this event.", "node", node.Name, "state", &state, "traceCtx", ctx)
-					}
-				}
+					state.ShouldDrain = true // setting the drain decision to true unless we can overturn it
 
-				if state.ShouldDrain {
-					// cordon the node, then drain
-					log.Infow("A drain has been determined as appropriate for the node", "node", node.Name, "state", &state, "traceCtx", ctx)
-
-					// check state and attempt to cordon if required
-					if state.IsCordoned {
-						log.Infow("Node is already cordoned, skipping cordon", "node", node.Name, "state", &state, "traceCtx", ctx)
-						recorder.Eventf(node, v1.EventTypeNormal, "CordonNode", "Node %s is already cordoned, no need to attempt a cordon.", node.Name)
-					} else {
-						b, err := n.CordonNode(ctx, clientset, node)
+					// if the condition is a scheduled event, we need to check and differentiate between a freeze event and a live migration
+					if state.ConditionIsScheduledEvent {
+						log.Infow("Node has a scheduled event condition, checking for freeze or live migration", "node", node.Name, "state", &state, "traceCtx", ctx)
+						isLM, err := imds.CheckIfFreezeOrLiveMigration(ctx, ic, node, &cfg.ScheduledEventDrainConditions)
 						if err != nil {
-							log.Errorw("Failed to cordon node", "node", node.Name, "error", err, "traceCtx", ctx)
-							recorder.Eventf(node, v1.EventTypeWarning, "CordonNode", "Failed to cordon node %s", node.Name)
+							log.Errorw("Failed to query IMDS for scheduled event information. Unable to determine if drain is required.", "error", err, "state", &state, "traceCtx", ctx)
+							return
+						}
+
+						if !isLM && !cfg.ScheduledEventDrainConditions.Freeze {
+							log.Infow("Node has a freeze event that is not a live migration. We don't currently drain for freeze events, so setting our drain decision to false.", "node", node.Name, "state", &state, "traceCtx", ctx)
+							state.ShouldDrain = false
+						} else if isLM && !cfg.ScheduledEventDrainConditions.LiveMigration {
+							log.Infow("Node has a live migration event but draining for live migration is disabled. Setting our drain decision to false.", "node", node.Name, "state", &state, "traceCtx", ctx)
+							state.ShouldDrain = false
 						} else {
-							state.IsCordoned = b
-							log.Infow("Node cordoned", "node", node.Name, "state", &state, "traceCtx", ctx)
-							recorder.Eventf(node, v1.EventTypeNormal, "CordonNode", "Node %s cordoned by mechanic", node.Name)
+							log.Infow("Node has a scheduled event condition that is a live migration. We will drain for this event.", "node", node.Name, "state", &state, "traceCtx", ctx)
 						}
 					}
 
-					if state.IsDrained {
-						log.Infow("Node is already drained, skipping drain", "node", node.Name, "traceCtx", ctx)
-					} else {
-						b, err := n.DrainNode(ctx, clientset, node)
-						if err != nil {
-							log.Errorw("Failed to drain node", "node", node.Name, "error", err, "traceCtx", ctx)
-							recorder.Eventf(node, v1.EventTypeWarning, "DrainNode", "Failed to drain node %s", node.Name)
+					if state.ShouldDrain {
+						// cordon the node, then drain
+						log.Infow("A drain has been determined as appropriate for the node", "node", node.Name, "state", &state, "traceCtx", ctx)
+
+						// check state and attempt to cordon if required
+						if state.IsCordoned {
+							log.Infow("Node is already cordoned, skipping cordon", "node", node.Name, "state", &state, "traceCtx", ctx)
+							recorder.Eventf(node, v1.EventTypeNormal, "CordonNode", "Node %s is already cordoned, no need to attempt a cordon.", node.Name)
 						} else {
-							state.IsDrained = b
-							log.Infow("Node drain completed", "node", node.Name, "state", &state, "traceCtx", ctx)
-							recorder.Eventf(node, v1.EventTypeNormal, "DrainNode", "Node %s drained by mechanic", node.Name)
+							b, err := n.CordonNode(ctx, clientset, node)
+							if err != nil {
+								log.Errorw("Failed to cordon node", "node", node.Name, "error", err, "traceCtx", ctx)
+								recorder.Eventf(node, v1.EventTypeWarning, "CordonNode", "Failed to cordon node %s", node.Name)
+							} else {
+								state.IsCordoned = b
+								log.Infow("Node cordoned", "node", node.Name, "state", &state, "traceCtx", ctx)
+								recorder.Eventf(node, v1.EventTypeNormal, "CordonNode", "Node %s cordoned by mechanic", node.Name)
+							}
+						}
+
+						if state.IsDrained {
+							log.Infow("Node is already drained, skipping drain", "node", node.Name, "traceCtx", ctx)
+						} else {
+							b, err := n.DrainNode(ctx, clientset, node)
+							if err != nil {
+								log.Errorw("Failed to drain node", "node", node.Name, "error", err, "traceCtx", ctx)
+								recorder.Eventf(node, v1.EventTypeWarning, "DrainNode", "Failed to drain node %s", node.Name)
+							} else {
+								state.IsDrained = b
+								log.Infow("Node drain completed", "node", node.Name, "state", &state, "traceCtx", ctx)
+								recorder.Eventf(node, v1.EventTypeNormal, "DrainNode", "Node %s drained by mechanic", node.Name)
+							}
 						}
 					}
 				}
-			}
-			// finished the event checking, cordon, and drain logic. checking for unneeded cordons now. grab an updated
-			// node object that should reflect all of our changes and use that for the ValidateCordon
-			log.Infow("Checking for unneeded cordon", "node", node.Name, "state", &state, "traceCtx", ctx)
-			updated, err := clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
-			if err != nil {
-				log.Errorw("Failed to get updated node object", "node", node.Name, "error", err, "state", &state, "traceCtx", ctx)
-				return
-			}
-			n.ValidateCordon(ctx, clientset, updated, recorder)
+				// finished the event checking, cordon, and drain logic. checking for unneeded cordons now. grab an updated
+				// node object that should reflect all of our changes and use that for the ValidateCordon
+				log.Infow("Checking for unneeded cordon", "node", node.Name, "state", &state, "traceCtx", ctx)
+				updated, err := clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+				if err != nil {
+					log.Errorw("Failed to get updated node object", "node", node.Name, "error", err, "state", &state, "traceCtx", ctx)
+					return
+				}
+				n.ValidateCordon(ctx, clientset, updated, recorder)
 
-			log.Infow("Finished processing node update", "node", node.Name, "state", &state, "traceCtx", ctx)
-		},
-	})
+				log.Infow("Finished processing node update", "node", node.Name, "state", &state, "traceCtx", ctx)
+			},
+		})
 
-	stop := make(chan struct{})
-	defer close(stop)
+		stop := make(chan struct{})
+		defer close(stop)
 
-	// start the informer
-	log.Infow("Starting the informer", "node", cfg.NodeName)
-	factory.Start(stop)
+		// start the informer
+		log.Infow("Starting the informer", "node", cfg.NodeName)
+		factory.Start(stop)
 
-	// wait for caches to sync
-	if !cache.WaitForCacheSync(stop, ni.HasSynced) {
-		log.Errorw("Failed to sync informer caches")
+		// wait for caches to sync
+		if !cache.WaitForCacheSync(stop, ni.HasSynced) {
+			log.Errorw("Failed to sync informer caches")
+		}
+
+		// block main process
+		<-stop
+	}
+}
+
+// handleIMDSCheck performs the IMDS check and node processing logic when bypassing Node Problem Detector
+func handleIMDSCheck(ctx context.Context, clientset kubernetes.Interface, cfg *config.Config, state *appstate.State, ic *imds.IMDSClient, recorder record.EventRecorder, tracer trace.Tracer, log *zap.SugaredLogger) {
+	ctx, span := tracer.Start(ctx, "handleIMDSCheck")
+	defer span.End()
+
+	// lock the state object so we know we have it exclusively for this function
+	didLock := state.Lock.TryLock()
+	if !didLock {
+		log.Warnw("Failed to lock state object, skipping IMDS check",
+			"node", cfg.NodeName,
+			"traceCtx", ctx)
+		return
+	}
+	log.Debugw("Locked state object for IMDS check", "node", cfg.NodeName,
+		"state", state,
+		"traceCtx", ctx)
+	defer func() {
+		state.Lock.Unlock()
+		log.Debugw("Unlocked state object after IMDS check",
+			"node", cfg.NodeName,
+			"state", state,
+			"traceCtx", ctx)
+	}()
+
+	// Get current node state
+	node, err := clientset.CoreV1().Nodes().Get(ctx, cfg.NodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorw("Failed to get node during IMDS check", "error", err, "node", cfg.NodeName, "traceCtx", ctx)
+		return
 	}
 
-	// block main process
-	<-stop
+	log.Infow("Performing IMDS check for node", "node", node.Name, "traceCtx", ctx)
+
+	// Update cordon state from current node status
+	state.IsCordoned = node.Spec.Unschedulable
+
+	// Check IMDS directly for drain requirements
+	shouldDrain, err := imds.CheckIfDrainRequired(ctx, ic, node, &cfg.ScheduledEventDrainConditions, &cfg.OptionalDrainConditions)
+	if err != nil {
+		log.Errorw("Failed to check if drain is required from IMDS", "error", err, "node", node.Name, "traceCtx", ctx)
+		return
+	}
+
+	// Update state based on IMDS check
+	state.HasDrainableCondition = shouldDrain
+	state.ShouldDrain = shouldDrain
+
+	log.Infow("Finished IMDS check", "node", node.Name, "shouldDrain", shouldDrain, "state", state, "traceCtx", ctx)
+
+	if state.HasDrainableCondition && state.ShouldDrain {
+		// early return if the node is already cordoned and drained
+		if state.IsCordoned && state.IsDrained {
+			log.Infow("Node is already cordoned and drained, no action required", "node", node.Name, "state", state, "traceCtx", ctx)
+			return
+		}
+
+		log.Infow("IMDS check determined drain is required for the node", "node", node.Name, "state", state, "traceCtx", ctx)
+
+		// check state and attempt to cordon if required
+		if state.IsCordoned {
+			log.Infow("Node is already cordoned, skipping cordon", "node", node.Name, "state", state, "traceCtx", ctx)
+			recorder.Eventf(node, v1.EventTypeNormal, "CordonNode", "Node %s is already cordoned, no need to attempt a cordon.", node.Name)
+		} else {
+			b, err := n.CordonNode(ctx, clientset, node)
+			if err != nil {
+				log.Errorw("Failed to cordon node", "node", node.Name, "error", err, "traceCtx", ctx)
+				recorder.Eventf(node, v1.EventTypeWarning, "CordonNode", "Failed to cordon node %s", node.Name)
+			} else {
+				state.IsCordoned = b
+				log.Infow("Node cordoned", "node", node.Name, "state", state, "traceCtx", ctx)
+				recorder.Eventf(node, v1.EventTypeNormal, "CordonNode", "Node %s cordoned by mechanic", node.Name)
+			}
+		}
+
+		if state.IsDrained {
+			log.Infow("Node is already drained, skipping drain", "node", node.Name, "traceCtx", ctx)
+		} else {
+			b, err := n.DrainNode(ctx, clientset, node)
+			if err != nil {
+				log.Errorw("Failed to drain node", "node", node.Name, "error", err, "traceCtx", ctx)
+				recorder.Eventf(node, v1.EventTypeWarning, "DrainNode", "Failed to drain node %s", node.Name)
+			} else {
+				state.IsDrained = b
+				log.Infow("Node drain completed", "node", node.Name, "state", state, "traceCtx", ctx)
+				recorder.Eventf(node, v1.EventTypeNormal, "DrainNode", "Node %s drained by mechanic", node.Name)
+			}
+		}
+	}
+
+	// Check for unneeded cordon
+	log.Infow("Checking for unneeded cordon", "node", node.Name, "state", state, "traceCtx", ctx)
+	updated, err := clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+	if err != nil {
+		log.Errorw("Failed to get updated node object", "node", node.Name, "error", err, "state", state, "traceCtx", ctx)
+		return
+	}
+	n.ValidateCordon(ctx, clientset, updated, recorder)
+
+	log.Infow("Finished processing IMDS check", "node", node.Name, "state", state, "traceCtx", ctx)
 }

--- a/deploy/base/mechanic.ds.yaml
+++ b/deploy/base/mechanic.ds.yaml
@@ -111,6 +111,7 @@ data:
       fsCorrupt: true
     runtimeEnv: prod
     enableTracing: true
+    bypassNodeProblemDetector: false
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,10 +33,11 @@ type OptionalDrainConditions struct {
 
 // MechanicConfig represents the full configuration structure from mechanic.yaml
 type MechanicConfig struct {
-	ScheduledEvents ScheduledEventDrainConditions `mapstructure:"scheduledEvents"`
-	Optional        OptionalDrainConditions       `mapstructure:"optionalConditions"`
-	RuntimeEnv      string                        `mapstructure:"runtimeEnv"`
-	EnableTracing   bool                          `mapstructure:"enableTracing"`
+	ScheduledEvents           ScheduledEventDrainConditions `mapstructure:"scheduledEvents"`
+	Optional                  OptionalDrainConditions       `mapstructure:"optionalConditions"`
+	RuntimeEnv                string                        `mapstructure:"runtimeEnv"`
+	EnableTracing             bool                          `mapstructure:"enableTracing"`
+	BypassNodeProblemDetector bool                          `mapstructure:"bypassNodeProblemDetector"`
 }
 
 // ContextValues is a struct that holds the logger and state of the application for use in the shared application context
@@ -54,6 +55,7 @@ type Config struct {
 	KubeConfig                    *rest.Config
 	NodeName                      string
 	EnableTracing                 bool
+	BypassNodeProblemDetector     bool
 }
 
 func ReadConfiguration(ctx context.Context) (Config, error) {
@@ -81,8 +83,9 @@ func ReadConfiguration(ctx context.Context) (Config, error) {
 			FrequentContainerdRestarts: false,
 			FsCorrupt:                  false,
 		},
-		RuntimeEnv:    "prod",
-		EnableTracing: true,
+		RuntimeEnv:                "prod",
+		EnableTracing:             true,
+		BypassNodeProblemDetector: false,
 	}
 
 	// Set up Viper to find and read the config file
@@ -122,6 +125,7 @@ func ReadConfiguration(ctx context.Context) (Config, error) {
 		NodeName:                      config.GetString("NODE_NAME"),
 		EnableTracing:                 mechanicConfig.EnableTracing,
 		RuntimeEnv:                    mechanicConfig.RuntimeEnv,
+		BypassNodeProblemDetector:     mechanicConfig.BypassNodeProblemDetector,
 	}, nil
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, mechanic has a hard dependency on node problem detector and leverages its node condition changes to trigger IMDS logic and determine if a node needs to be cordoned and/or drained.

Issue Number: #50 

## What is the new behavior?

This PR introduces:

- A `bypassNodeProblemDetector` config value that toggles if we set up the Kubernetes informer for node changes or not.
- A logic loop that runs every 10 seconds (with a jitter of +-0.5 seconds) that locks the state, queries IMDS for pending events, and applies the same checks for cordoning and draining that are used in the informer code path.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
This PR also includes updates to documentation as required and targets the v2025.7 milestone release.